### PR TITLE
Add provider-agnostic LLM layer with OpenRouter adapter

### DIFF
--- a/backend/core/settings.py
+++ b/backend/core/settings.py
@@ -67,6 +67,7 @@ INSTALLED_APPS = [
     "catalogs.apps.CatalogsConfig",
     "diary.apps.DiaryConfig",
     "bot.apps.BotConfig",
+    "llm.apps.LlmConfig",
 ]
 
 if DEBUG:
@@ -176,3 +177,10 @@ BOT_TOKEN = env("BOT_TOKEN")
 BOT_WEBHOOK_URL = env("BOT_WEBHOOK_URL", default=None)
 BOT_WEBHOOK_TOKEN = env("BOT_WEBHOOK_TOKEN", default=None)
 BOT_DROP_PENDING_UPDATES = env.bool("BOT_DROP_PENDING_UPDATES", default=True)
+
+# LLM providers
+
+OPENROUTER_API_KEY = env("OPENROUTER_API_KEY", default="")
+LLM_DEFAULT_MODEL = env("LLM_DEFAULT_MODEL", default="openai/gpt-4o-mini")
+LLM_REQUEST_TIMEOUT_SECONDS = env.int("LLM_REQUEST_TIMEOUT_SECONDS", default=30)
+LLM_MAX_RETRIES = env.int("LLM_MAX_RETRIES", default=2)

--- a/backend/llm/apps.py
+++ b/backend/llm/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class LlmConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "llm"

--- a/backend/llm/clients/__init__.py
+++ b/backend/llm/clients/__init__.py
@@ -1,0 +1,3 @@
+from .openrouter import OpenRouterClient
+
+__all__ = ["OpenRouterClient"]

--- a/backend/llm/clients/openrouter.py
+++ b/backend/llm/clients/openrouter.py
@@ -1,0 +1,130 @@
+import json
+import socket
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+from django.conf import settings
+
+from llm.errors import LLMProviderError, LLMRateLimitError, LLMTimeoutError
+from llm.interfaces import LLMClient
+
+
+class OpenRouterClient(LLMClient):
+    """OpenRouter adapter implementing the provider-agnostic LLM interface."""
+
+    endpoint = "https://openrouter.ai/api/v1/chat/completions"
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        default_model: str | None = None,
+        timeout_seconds: int | None = None,
+        max_retries: int | None = None,
+    ):
+        self.api_key = api_key or settings.OPENROUTER_API_KEY
+        self.default_model = default_model or settings.LLM_DEFAULT_MODEL
+        self.timeout_seconds = timeout_seconds or settings.LLM_REQUEST_TIMEOUT_SECONDS
+        self.max_retries = (
+            max_retries if max_retries is not None else settings.LLM_MAX_RETRIES
+        )
+
+        if self.timeout_seconds is None or self.timeout_seconds <= 0:
+            raise ValueError("LLM_REQUEST_TIMEOUT_SECONDS must be > 0")
+        if self.max_retries < 0:
+            raise ValueError("LLM_MAX_RETRIES must be >= 0")
+
+        if not self.api_key:
+            raise ValueError("OPENROUTER_API_KEY is required for OpenRouterClient")
+
+    def chat_completion(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        system_message: str | None = None,
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        request_messages = self._compose_messages(messages, system_message)
+        payload: dict[str, Any] = {
+            "model": model or self.default_model,
+            "messages": request_messages,
+            "temperature": temperature,
+        }
+
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+
+        if tools:
+            payload["tools"] = tools
+
+        return self._post_with_retries(payload)
+
+    def supports_tools(self) -> bool:
+        return True
+
+    def _compose_messages(
+        self, messages: list[dict[str, str]], system_message: str | None
+    ) -> list[dict[str, str]]:
+        composed_messages: list[dict[str, str]] = []
+        if system_message:
+            composed_messages.append({"role": "system", "content": system_message})
+        composed_messages.extend(messages)
+        return composed_messages
+
+    def _post_with_retries(self, payload: dict[str, Any]) -> dict[str, Any]:
+        encoded_payload = json.dumps(payload).encode("utf-8")
+
+        for attempt in range(self.max_retries + 1):
+            try:
+                request = urllib.request.Request(
+                    self.endpoint,
+                    data=encoded_payload,
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    method="POST",
+                )
+                with urllib.request.urlopen(
+                    request,
+                    timeout=self.timeout_seconds,
+                ) as response:
+                    raw_body = response.read().decode("utf-8")
+                    parsed = json.loads(raw_body)
+                    return parsed
+            except urllib.error.HTTPError as error:
+                if error.code == 429:
+                    if attempt < self.max_retries:
+                        time.sleep(2**attempt)
+                        continue
+                    raise LLMRateLimitError("OpenRouter rate limit exceeded") from error
+
+                error_body = error.read().decode("utf-8", errors="replace")
+                raise LLMProviderError(
+                    f"OpenRouter request failed: {error_body}",
+                    status_code=error.code,
+                ) from error
+            except urllib.error.URLError as error:
+                is_timeout = isinstance(error.reason, (TimeoutError, socket.timeout))
+                if is_timeout and attempt < self.max_retries:
+                    time.sleep(2**attempt)
+                    continue
+                if is_timeout:
+                    raise LLMTimeoutError("OpenRouter request timed out") from error
+                raise LLMProviderError(
+                    f"OpenRouter network error: {error.reason}"
+                ) from error
+            except (TimeoutError, socket.timeout) as error:
+                if attempt < self.max_retries:
+                    time.sleep(2**attempt)
+                    continue
+                raise LLMTimeoutError("OpenRouter request timed out") from error
+            except json.JSONDecodeError as error:
+                raise LLMProviderError(
+                    "Failed to decode OpenRouter response"
+                ) from error

--- a/backend/llm/errors.py
+++ b/backend/llm/errors.py
@@ -1,0 +1,18 @@
+class LLMClientError(Exception):
+    """Base error class for all LLM client failures."""
+
+
+class LLMTimeoutError(LLMClientError):
+    """Raised when provider request times out."""
+
+
+class LLMRateLimitError(LLMClientError):
+    """Raised when provider rate limits a request."""
+
+
+class LLMProviderError(LLMClientError):
+    """Raised for provider-side errors or malformed responses."""
+
+    def __init__(self, message: str, *, status_code: int | None = None):
+        super().__init__(message)
+        self.status_code = status_code

--- a/backend/llm/factory.py
+++ b/backend/llm/factory.py
@@ -1,0 +1,15 @@
+from llm.clients import OpenRouterClient
+from llm.interfaces import LLMClient
+
+
+class LLMProviderFactory:
+    """Build LLM clients by provider name."""
+
+    @staticmethod
+    def create(provider: str = "openrouter") -> LLMClient:
+        normalized_provider = provider.strip().lower()
+
+        if normalized_provider == "openrouter":
+            return OpenRouterClient()
+
+        raise ValueError(f"Unsupported LLM provider: {provider}")

--- a/backend/llm/interfaces.py
+++ b/backend/llm/interfaces.py
@@ -1,0 +1,37 @@
+from abc import ABC, abstractmethod
+from collections.abc import Iterator
+from typing import Any
+
+
+class LLMClient(ABC):
+    """Provider-agnostic interface for chat completion clients."""
+
+    @abstractmethod
+    def chat_completion(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        system_message: str | None = None,
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> dict[str, Any]:
+        """Send a chat completion request and return raw provider response."""
+
+    def stream_chat_completion(
+        self,
+        *,
+        messages: list[dict[str, str]],
+        system_message: str | None = None,
+        model: str | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+    ) -> Iterator[dict[str, Any]]:
+        """Optional streaming API; implementations may override this method."""
+        raise NotImplementedError("Streaming is not supported by this client")
+
+    def supports_tools(self) -> bool:
+        """Optional capability flag for tool-calling requests."""
+        return False

--- a/backend/llm/tests.py
+++ b/backend/llm/tests.py
@@ -1,0 +1,66 @@
+import json
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from llm.clients.openrouter import OpenRouterClient
+from llm.errors import LLMRateLimitError
+
+
+class FakeResponse:
+    def __init__(self, payload: dict):
+        self.payload = payload
+
+    def read(self):
+        return json.dumps(self.payload).encode("utf-8")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+@override_settings(
+    OPENROUTER_API_KEY="test-key",
+    LLM_DEFAULT_MODEL="openai/gpt-4o-mini",
+    LLM_REQUEST_TIMEOUT_SECONDS=1,
+    LLM_MAX_RETRIES=0,
+)
+class OpenRouterClientTests(SimpleTestCase):
+    def test_chat_completion_sends_system_and_user_messages(self):
+        with patch("urllib.request.urlopen", return_value=FakeResponse({"id": "ok"})) as mocked_urlopen:
+            client = OpenRouterClient()
+            result = client.chat_completion(
+                messages=[{"role": "user", "content": "hi"}],
+                system_message="be brief",
+            )
+
+        self.assertEqual(result["id"], "ok")
+        request = mocked_urlopen.call_args.args[0]
+        payload = json.loads(request.data.decode("utf-8"))
+        self.assertEqual(payload["model"], "openai/gpt-4o-mini")
+        self.assertEqual(
+            payload["messages"],
+            [
+                {"role": "system", "content": "be brief"},
+                {"role": "user", "content": "hi"},
+            ],
+        )
+
+    def test_rate_limit_maps_to_internal_error(self):
+        from urllib.error import HTTPError
+        from io import BytesIO
+
+        error = HTTPError(
+            url="https://example.com",
+            code=429,
+            msg="rate limit",
+            hdrs=None,
+            fp=BytesIO(b"{}"),
+        )
+
+        with patch("urllib.request.urlopen", side_effect=error):
+            client = OpenRouterClient()
+            with self.assertRaises(LLMRateLimitError):
+                client.chat_completion(messages=[{"role": "user", "content": "hi"}])


### PR DESCRIPTION
### Motivation
- Introduce a provider-agnostic LLM client layer to decouple backend service code from specific LLM providers and make it easy to add new adapters.
- Provide structured error mapping and configuration so caller code can handle timeouts, rate limits and provider errors uniformly.

### Description
- Add a new Django app `llm` with the provider-agnostic interface `LLMClient` at `llm/interfaces.py` exposing `chat_completion`, optional `stream_chat_completion`, and `supports_tools` methods.
- Add structured internal error types `LLMClientError`, `LLMTimeoutError`, `LLMRateLimitError`, and `LLMProviderError` in `llm/errors.py`.
- Implement `OpenRouterClient` in `llm/clients/openrouter.py` which calls the OpenRouter chat completions endpoint and supports configurable `model`, `system/user` messages composition, `temperature`, `max_tokens`, request `timeout`, `max_retries`, and optional `tools` payloads, and maps transport/provider failures into the internal error types.
- Add a minimal `LLMProviderFactory` in `llm/factory.py` and register the `llm` app plus new configuration keys in `backend/core/settings.py` for `OPENROUTER_API_KEY`, `LLM_DEFAULT_MODEL`, `LLM_REQUEST_TIMEOUT_SECONDS`, and `LLM_MAX_RETRIES` so transport logic stays isolated and new providers only require new adapter files.
- Add unit tests in `backend/llm/tests.py` covering request payload composition and rate-limit error mapping for the OpenRouter adapter.

### Testing
- Ran `python -m compileall backend/llm backend/core/settings.py` which succeeded.
- Attempted to run the Django test suite with `SECRET_KEY=test BOT_TOKEN=123 python backend/manage.py test llm` but the run fails in this environment during project import/checks due to a missing third-party dependency (`async_timeout`) pulled in via `aiogram`; the failure is environmental and unrelated to the `llm` adapter code itself.
- Added `backend/llm/tests.py` which exercises payload composition and rate-limit error mapping for `OpenRouterClient` (these tests are included in the repository).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a29bc3d984832c8bfed1b367cbc3c1)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added language model integration with OpenRouter API support
  * Configurable API credentials, default model selection, request timeouts, and automatic retry handling
  * Enhanced error handling for rate limits, timeouts, and API failures
  * Support for tool-calling in language model requests

<!-- end of auto-generated comment: release notes by coderabbit.ai -->